### PR TITLE
Bugfix/flcrm 6094

### DIFF
--- a/ext/filegdb/extconf.rb
+++ b/ext/filegdb/extconf.rb
@@ -8,6 +8,8 @@ have_library 'FileGDBAPI' or raise 'libFileGDBAPI not found'
 
 $libs = append_library $libs, 'FileGDBAPI'
 
+$CXXFLAGS += " -D_GLIBCXX_USE_CXX11_ABI=0 "
+
 if `ld --help | grep disable-new-dtags | wc -l`.strip == '1'
   $LDFLAGS << " -Wl,--disable-new-dtags"
 end

--- a/filegdb.gemspec
+++ b/filegdb.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake',          ['>= 0']
   gem.add_development_dependency 'rake-compiler', ['>= 0']
-  gem.add_development_dependency 'rspec',         ['~> 2.14.1']
+  gem.add_development_dependency 'rspec',         ['>= 0']
+  gem.add_development_dependency 'rspec-collection_matchers', ['>= 0']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec/collection_matchers'
 require 'filegdb'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Disabling the use of the new C++ 11 ABI since it causes issues with the ESRI filegdb library. Supposedly this is fixed in the newer version of the library but when I attempted to upgrade it still had the same issue.

At some point we probably want to upgrade to version 1.5 but since it did not solve our issue it doesn't seem necessary or urgent.